### PR TITLE
Create Dockerfile for Align only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:2.7.17-buster
+
+RUN apt-get -y update && apt-get install -y --fix-missing \
+    build-essential \
+    cmake \
+    gfortran \
+    git \
+    wget \
+    curl \
+    graphicsmagick \
+    libgraphicsmagick1-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libgtk2.0-dev \
+    libjpeg-dev \
+    liblapack-dev \
+    libswscale-dev \
+    pkg-config \
+    python3-dev \
+    python3-numpy \
+    software-properties-common \
+    zip \
+    && apt-get clean && rm -rf /tmp/* /var/tmp/*
+
+RUN cd ~ && \
+    mkdir -p dlib && \
+    git clone -b 'v19.9' --single-branch https://github.com/davisking/dlib.git dlib/ && \
+    cd  dlib/ && \
+    python setup.py install --yes USE_AVX_INSTRUCTIONS
+    #python3 setup.py install --yes USE_AVX_INSTRUCTIONS
+
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .


### PR DESCRIPTION
Tested:
download shape_predictor_68_face_landmarks.dat
copy pada.conf from `examples` into root
edit to point to shape_predictor_68_face_landmarks.dat
$ docker build -t aligner .
$ docker run -v `pwd`/../input:/usr/src/app/input -v `pwd`/../aligned:/usr/src/app/aligned -it aligner  /bin/bash